### PR TITLE
support for dub 0.9.24

### DIFF
--- a/autoload/dutyl/dub.vim
+++ b/autoload/dutyl/dub.vim
@@ -13,7 +13,7 @@ endfunction
 
 let s:functions={}
 
-let s:DEFINING_FILES = ['dub.json', 'package.json', 'dub.selections.json']
+let s:DEFINING_FILES = ['dub.sdl', 'dub.json', 'package.json', 'dub.selections.json']
 
 function! s:functions.projectRoot() abort
     let l:dubFileMatches=dutyl#util#globInParentDirectories(s:DEFINING_FILES)
@@ -73,8 +73,8 @@ function! s:dubDescribe() abort
     let l:result=substitute(l:result,'\v(^|\n|\r)There was no.{-}($|\n|\r)','','g')
 
     "Replace true with 1 and false with 0
-    let l:result=substitute(l:result,'\vtrue\,?[\n\r]','1\n','g')
-    let l:result=substitute(l:result,'\vfalse\,?[\n\r]','0\n','g')
+    let l:result=substitute(l:result,'\vtrue(\,?)[\n\r]','1\1\n','g')
+    let l:result=substitute(l:result,'\vfalse(\,?)[\n\r]','0\1\n','g')
 
     "Remove linefeeds
     let l:result=substitute(l:result,'\v[\n\r]',' ','g')


### PR DESCRIPTION
Detecting the new dub.sdl that is replacing dub.json.
Corrected substitution pattern for true/false that was removing the comma.

Hello,

I noticed a bug in vim-dutyl substitution.
I hope the solution in this pull request is of adequate quality. Be aware that I have only tested this solution with dub-0.9.23 and dub-0.9.24-rc.1.

The example below demonstrates the problem.
Notice the missing comma at the end of the line when the pattern below is ran.
:,$s/\vtrue\,?[\n\r]/1\r/
Seems to be fixed by grouping the comma and reusing the group in substitution.
:,$s/\vtrue(\,?)[\n\r]/1\1\r/

			"active": true,