### PR TITLE
Fix for DCD 0.7+

### DIFF
--- a/autoload/dutyl/core.vim
+++ b/autoload/dutyl/core.vim
@@ -180,7 +180,7 @@ function! dutyl#core#runToolInBackground(tool,args) abort
     if has('win32')
         silent execute '!start '.s:createRunToolCommandIgnoreVimproc(a:tool,a:args)
     else
-        silent execute '!'.s:createRunToolCommand(a:tool,a:args).' > /dev/null &'
+        silent execute '!'.s:createRunToolCommand(a:tool,a:args).' > /dev/null 2>&1 &'
     endif
 endfunction
 

--- a/doc/dutyl.txt
+++ b/doc/dutyl.txt
@@ -4,7 +4,7 @@
 Author:  Idan Arye <https://github.com/idanarye/>
 License: Same terms as Vim itself (see |license|)
 
-Version: 1.5.2
+Version: 1.5.2+
 
 INTRODUCTION                                                         *dutyl*
 


### PR DESCRIPTION
DCD is using stderr for logging.
Ignoring stderr for all commands that are ran in the background.