### PR TITLE
Fix: When dutyl call dub failed, dcd can't get the import path in g:dutyl_stdImportPaths

### DIFF
--- a/autoload/dutyl/dub.vim
+++ b/autoload/dutyl/dub.vim
@@ -41,19 +41,23 @@ function! s:functions.importPaths() dict abort
         endif
     endif
 
-    let l:info=s:dubDescribe()
-    for l:package in l:info.packages
-        for l:importPath in l:package.importPaths
-            if dutyl#util#isPathAbsolute(l:importPath)
-                call add(l:result,l:importPath)
-            else
-                let l:absoluteImportPath=globpath(l:package.path,l:importPath,1)
-                if !empty(l:absoluteImportPath)
-                    call add(l:result,l:absoluteImportPath)
+    try
+        let l:info=s:dubDescribe()
+        for l:package in l:info.packages
+            for l:importPath in l:package.importPaths
+                if dutyl#util#isPathAbsolute(l:importPath)
+                    call add(l:result,l:importPath)
+                else
+                    let l:absoluteImportPath=globpath(l:package.path,l:importPath,1)
+                    if !empty(l:absoluteImportPath)
+                        call add(l:result,l:absoluteImportPath)
+                    endif
                 endif
-            endif
+            endfor
         endfor
-    endfor
+    catch /.*/
+        echo "Can not get dub project import path!"
+    endtry
 
     let self.cache.dub.importPaths = dutyl#util#normalizePaths(l:result)
     let self.cache.dub.definingFilesModificationTime = l:definingFilesModificationTime


### PR DESCRIPTION
Catch the exception when dutyl can't get import path from dub. Now in any case, the `g:dutyl_stdImportPaths` will take effect.