### PR TITLE
Fix for "Paths with spaces don't work"

### DIFF
--- a/autoload/dutyl/util.vim
+++ b/autoload/dutyl/util.vim
@@ -123,14 +123,16 @@ endfunction
 "directory
 function! dutyl#util#runInDirectory(directory,action,...) abort
     let l:cwd=getcwd()
-    try
-        execute 'lcd '.a:directory
+    try 
+        let l:directory = substitute(a:directory, "\ ", '\\ ', "g")
+        execute 'lcd '.l:directory
         if type(function('tr'))==type(a:action)
             return call(a:action,a:000)
         elseif type('')==type(a:action)
             execute a:action
         endif
     finally
+        let l:cwd = substitute(l:cwd, "\ ", '\\ ', "g")
         execute 'lcd '.l:cwd
     endtry
 endfunction


### PR DESCRIPTION
This pull request fixes the issue listed under "Issues" titled "Paths with spaces don't work." I've copied the code listed there verbatim and tested it on my machine. It works to my satisfaction. The code used is: 

"lcd to the directory, run the function or command, and return to the current
"directory
function! dutyl#util#runInDirectory(directory,action,...) abort
    let l:cwd=getcwd()
    try 
        let l:directory = substitute(a:directory, "\ ", '\\ ', "g")
        execute 'lcd '.l:directory
        if type(function('tr'))==type(a:action)
            return call(a:action,a:000)
        elseif type('')==type(a:action)
            execute a:action
        endif
    finally
        let l:cwd = substitute(l:cwd, "\ ", '\\ ', "g")
        execute 'lcd '.l:cwd
    endtry
endfunction