### PR TITLE
Fix #34 - Fix paths with spaces don't work the right way

### DIFF
--- a/autoload/dutyl/util.vim
+++ b/autoload/dutyl/util.vim
@@ -122,9 +122,9 @@ endfunction
 "lcd to the directory, run the function or command, and return to the current
 "directory
 function! dutyl#util#runInDirectory(directory,action,...) abort
-    let l:cwd=substitute(getcwd(), "\ ", '\\ ', "g")
+    let l:cwd=fnameescape(getcwd())
     try 
-        let l:directory=substitute(a:directory, "\ ", '\\ ', "g")
+        let l:directory=fnameescape(a:directory)
         execute 'lcd '.l:directory
         if type(function('tr'))==type(a:action)
             return call(a:action,a:000)


### PR DESCRIPTION
Changed my fix to use fnameescape() which is apparently the right way to do things (and cleaner).