### PR TITLE
Return nothing with no completions are found (rather use echoerr)

### DIFF
--- a/autoload/dutyl/dcd.vim
+++ b/autoload/dutyl/dcd.vim
@@ -67,7 +67,8 @@ function! s:functions.complete(args) abort
 
     "if we have less than one line - something wen wrong
     if empty(l:resultLines)
-        return 'bad...'
+        echoerr 'bad...'
+        return
     endif
     "identify completion type via the first line.
     if l:resultLines[0]=='identifiers'


### PR DESCRIPTION
I'm very experienced, but new to D.

I am using https://github.com/maralla/completor.vim as my completion engine. With current behaviour, if there are no completions reported from `dcd-server`, the letters `b a d .` get shown in my completions list.  (So this issue is *only* for when my completion engine shows things like snips, etc., but there are no D completions at the current cursor location.  When dcd-server *does* return valid completions, there is no problem.)

This PR fixes that by rather using `echoerr` to write `bad...` instead of returning it.

Here is a screenshot of the problem:

![bad](https://user-images.githubusercontent.com/480395/37003626-7374eaae-2119-11e8-8fc6-4a84dda4487a.png)

Here is a screenshot with my PR applied:

![good](https://user-images.githubusercontent.com/480395/37003895-5518658a-211a-11e8-8fe3-fea020bc0b81.png)
