### PR TITLE
Echo dub describe exception error when importing paths

### DIFF
--- a/autoload/dutyl/dub.vim
+++ b/autoload/dutyl/dub.vim
@@ -56,7 +56,7 @@ function! s:functions.importPaths() dict abort
             endfor
         endfor
     catch /.*/
-        echo "Can not get dub project import path!"
+        echo "Can not get dub project import path! " . v:exception
     endtry
 
     let self.cache.dub.importPaths = dutyl#util#normalizePaths(l:result)
@@ -67,9 +67,9 @@ endfunction
 "Calls 'dub describe' and turns the result to Vim's data types
 function! s:dubDescribe() abort
     let l:result=dutyl#util#runInDirectory(s:functions.projectRoot(),
-                \function('dutyl#core#runTool'),'dub',['describe','--annotate', '--vquiet'])
+                \function('dutyl#core#runTool'),'dub',['describe','--annotate', '--verror'])
     if !empty(dutyl#core#shellReturnCode())
-        throw 'Failed to execute `dub describe`'
+        throw 'Failed to execute `dub describe --annotate`: ' . l:result
     endif
 
     "If package.json instead of dub.json or visa versa, dub will sometimes


### PR DESCRIPTION
This took me quite a while to track down.

The problem was that `dub describe --annotate` does not trigger downloads of not already downloaded dependencies which is why the command failed with "Non-optional dependency <dep> of <project> not found in dependency tree!?. ".

This commit just prints the error the `dub describe --annotate --verror` gives and hints towards `dub describe --annotate` as the source of error.

Please see comment in commit regarding l:result concatenation.